### PR TITLE
Fixed invisible text input bug

### DIFF
--- a/src/UI/text.js
+++ b/src/UI/text.js
@@ -47,6 +47,7 @@ function handleDocumentMouseup(e) {
   input.style.left = e.clientX + 'px';
   input.style.fontSize = _textSize + 'px';
   input.style.color = _textColor;
+  input.style.zIndex = 10;
 
   input.addEventListener('blur', handleInputBlur);
   input.addEventListener('keyup', handleInputKeyup);


### PR DESCRIPTION
For some reason the input field would be hidden behind the pdf. Increasing the 'z-index' fixed it.